### PR TITLE
External MMIO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ SRC_FILES = \
 	src/LoadSelector.sv \
 	src/LoadMissQueue.sv \
 	src/TLB.sv \
+	src/BypassLSU.sv \
 	hardfloat/addRecFN.v \
 	hardfloat/compareRecFN.v \
 	hardfloat/fNToRecFN.v \

--- a/Top_tb.cpp
+++ b/Top_tb.cpp
@@ -301,6 +301,7 @@ class SpikeSimif : public simif_t
             case 0x10000000:
             case 0x10000004:
             case 0x11100000:
+            case 0x11200000:
                 mem_pass_thru = true;
                 break; 
             }

--- a/src/BypassLSU.sv
+++ b/src/BypassLSU.sv
@@ -1,0 +1,106 @@
+module BypassLSU#(parameter RQ_ID = 2)
+(
+    input wire clk,
+    input wire rst,
+
+    input BranchProv IN_branch,
+    
+    input wire IN_uopLdEn,
+    output wire OUT_ldStall,
+    input LD_UOp IN_uopLd,
+
+    input wire IN_stall,
+    output LD_UOp OUT_uopLd,
+    output reg[31:0] OUT_ldData,
+
+    output CTRL_MemC OUT_memc,
+    input STAT_MemC IN_memc
+);
+
+// We need to be extremely careful that bypassing load/stores aren't cached (and no transaction to cache them is currently)
+// starting or in progress
+
+reg[31:0] result;
+LD_UOp activeLd;
+
+wire invalidateActiveLd = !(activeLd.external || !IN_branch.taken || $signed(activeLd.sqN - IN_branch.sqN) <= 0);
+
+enum logic[1:0]
+{
+    IDLE,
+    LOAD_RQ,
+    LOAD_ACTIVE,
+    LOAD_DONE
+} state;
+
+always_comb begin
+    OUT_ldStall = IN_uopLd.valid && IN_uopLdEn && state != IDLE;
+
+    OUT_uopLd = 'x;
+    OUT_uopLd.valid = 0;
+    OUT_ldData = 'x;
+
+    if (state == LOAD_DONE && !invalidateActiveLd) begin
+        OUT_uopLd = activeLd;
+        OUT_ldData = result;
+    end
+end
+
+always_ff@(posedge clk) begin
+    
+    if (rst) begin
+        activeLd.valid <= 0;
+        OUT_memc.cmd <= MEMC_NONE;
+        state <= IDLE;
+    end
+    else begin
+
+        if (invalidateActiveLd) begin
+            activeLd <= 'x;
+            activeLd.valid <= 0;
+        end
+
+        case (state)
+            IDLE: begin
+                if (IN_uopLdEn && !OUT_ldStall && 
+                    (IN_uopLd.external || !IN_branch.taken || $signed(IN_uopLd.sqN - IN_branch.sqN) <= 0)
+                ) begin
+                    activeLd <= IN_uopLd;
+
+                    OUT_memc.cmd <= MEMC_READ_SINGLE;
+                    OUT_memc.sramAddr <= 'x;
+                    OUT_memc.extAddr <= IN_uopLd.addr[31:2];
+                    OUT_memc.cacheID <= 'x;
+                    OUT_memc.rqID <= RQ_ID;
+
+                    state <= LOAD_RQ;
+                end
+            end
+            LOAD_RQ: begin
+                if (IN_memc.busy && IN_memc.rqID == RQ_ID) begin
+                    OUT_memc.cmd <= MEMC_NONE;
+                    state <= LOAD_ACTIVE;
+                end
+            end
+            LOAD_ACTIVE: begin
+                if (IN_memc.resultValid) begin
+                    result <= IN_memc.result;
+                    state <= LOAD_DONE;
+                    if (invalidateActiveLd)
+                        state <= IDLE;
+                end
+            end
+            LOAD_DONE: begin
+                if (!IN_stall || invalidateActiveLd) begin
+                    state <= IDLE;
+                    activeLd <= 'x;
+                    activeLd.valid <= 0;
+                end
+            end
+
+        endcase
+    end
+
+end
+
+endmodule

--- a/src/BypassLSU.sv
+++ b/src/BypassLSU.sv
@@ -9,7 +9,11 @@ module BypassLSU#(parameter RQ_ID = 2)
     output wire OUT_ldStall,
     input LD_UOp IN_uopLd,
 
-    input wire IN_stall,
+    input wire IN_uopStEn,
+    output wire OUT_stStall,
+    input ST_UOp IN_uopSt,
+
+    input wire IN_ldStall,
     output LD_UOp OUT_uopLd,
     output reg[31:0] OUT_ldData,
 
@@ -17,20 +21,20 @@ module BypassLSU#(parameter RQ_ID = 2)
     input STAT_MemC IN_memc
 );
 
-// We need to be extremely careful that bypassing load/stores aren't cached (and no transaction to cache them is currently)
-// starting or in progress
-
 reg[31:0] result;
+
 LD_UOp activeLd;
 
 wire invalidateActiveLd = !(activeLd.external || !IN_branch.taken || $signed(activeLd.sqN - IN_branch.sqN) <= 0);
 
-enum logic[1:0]
+enum logic[2:0]
 {
     IDLE,
     LOAD_RQ,
     LOAD_ACTIVE,
-    LOAD_DONE
+    LOAD_DONE,
+    STORE_RQ,
+    STORE_ACTIVE
 } state;
 
 always_comb begin
@@ -44,6 +48,10 @@ always_comb begin
         OUT_uopLd = activeLd;
         OUT_ldData = result;
     end
+end
+
+always_comb begin
+    OUT_stStall = (IN_uopSt.valid && IN_uopStEn && state != IDLE) || (IN_uopLdEn && !OUT_ldStall);
 end
 
 always_ff@(posedge clk) begin
@@ -61,8 +69,9 @@ always_ff@(posedge clk) begin
         end
 
         case (state)
-            IDLE: begin
-                if (IN_uopLdEn && !OUT_ldStall && 
+            default: begin
+                state <= IDLE;
+                if (IN_uopLd.valid && IN_uopLdEn && !OUT_ldStall && 
                     (IN_uopLd.external || !IN_branch.taken || $signed(IN_uopLd.sqN - IN_branch.sqN) <= 0)
                 ) begin
                     activeLd <= IN_uopLd;
@@ -74,6 +83,16 @@ always_ff@(posedge clk) begin
                     OUT_memc.rqID <= RQ_ID;
 
                     state <= LOAD_RQ;
+                end
+                else if (IN_uopSt.valid && IN_uopStEn && !OUT_stStall) begin
+                    OUT_memc.cmd <= MEMC_WRITE_SINGLE;
+                    OUT_memc.sramAddr <= 'x;
+                    OUT_memc.extAddr <= IN_uopSt.addr[31:2];
+                    OUT_memc.cacheID <= 'x;
+                    OUT_memc.rqID <= RQ_ID;
+                    OUT_memc.data <= IN_uopSt.data;
+
+                    state <= STORE_RQ;
                 end
             end
             LOAD_RQ: begin
@@ -91,13 +110,24 @@ always_ff@(posedge clk) begin
                 end
             end
             LOAD_DONE: begin
-                if (!IN_stall || invalidateActiveLd) begin
+                if (!IN_ldStall || invalidateActiveLd) begin
                     state <= IDLE;
                     activeLd <= 'x;
                     activeLd.valid <= 0;
                 end
             end
 
+            STORE_RQ: begin
+                if (IN_memc.busy && IN_memc.rqID == RQ_ID) begin
+                    OUT_memc.cmd <= MEMC_NONE;
+                    state <= STORE_ACTIVE;
+                end
+            end
+            STORE_ACTIVE: begin
+                if (!IN_memc.busy) begin
+                    state <= IDLE;
+                end
+            end
         endcase
     end
 

--- a/src/CacheController.sv
+++ b/src/CacheController.sv
@@ -214,6 +214,7 @@ wire[$clog2(ASSOC)-1:0] curOpAssocIdx = OUT_memc.sramAddr[CLSIZE_E+$clog2(LEN)-2
 
 always_ff@(posedge clk) begin
     reg temp = 0;
+    OUT_memc.data <= 'x;
 
     if (rst) begin
         OUT_memc.cmd <= MEMC_NONE;

--- a/src/CacheController.sv
+++ b/src/CacheController.sv
@@ -188,18 +188,21 @@ end
 CommonUOp outUops[TOTAL_UOPS-1:0];
 ST_UOp outStUOp_r;
 LD_UOp outLdUOp_r;
-always_comb begin
+reg[1:0] invalidate;
 
+always_comb begin
     OUT_uopLd = outLdUOp_r;
     OUT_uopLd.valid = outUops[0].valid;
     OUT_uopLd.addr = outUops[0].addr;
     OUT_uopLd.isMMIO = outUops[0].isMMIO;
     OUT_uopLd.external = outUops[0].external;
+    invalidate[0] = !IN_stall[0] || (IN_branch.taken && $signed(outLdUOp_r.sqN - IN_branch.sqN) >= 0);
 
     OUT_uopSt = outStUOp_r;
     OUT_uopSt.valid = outUops[1].valid;
     OUT_uopSt.addr = outUops[1].addr;
     OUT_uopSt.isMMIO = outUops[1].isMMIO;
+    invalidate[1] = !IN_stall[1];
     //OUT_uopSt.external = outUops[1].external;
 end
 
@@ -226,7 +229,7 @@ always_ff@(posedge clk) begin
         end
     end
     else begin
-        
+
         // Evict/Load State Machine
         case (state)
             default: state <= IDLE;
@@ -322,7 +325,7 @@ always_ff@(posedge clk) begin
         // Incoming UOps handling
         for (integer i = 0; i < TOTAL_UOPS; i=i+1) begin
             
-            if (!IN_stall[i]) begin
+            if (invalidate[i]) begin
                 outUops[i] <= 'x;
                 outUops[i].valid <= 0;
             end

--- a/src/CacheController.sv
+++ b/src/CacheController.sv
@@ -327,10 +327,10 @@ always_ff@(posedge clk) begin
                 outUops[i].valid <= 0;
             end
             
-            if (uops[i].valid && !flushActive && !stall[i]) begin
-                
+            if (uops[i].valid && !flushActive) begin
+
                 // Cache Management Ops
-                if (isMgmt[i] && state == IDLE) begin
+                if (isMgmt[i] && state == IDLE && !stall[i]) begin
 
                     reg dirty = ctable[cacheIdx[i]][cacheHitIdx[i]].dirty;
                     for (integer j = 0; j < TOTAL_UOPS; j=j+1)
@@ -365,7 +365,7 @@ always_ff@(posedge clk) begin
                 end
 
                 // MMIO
-                else if (isMMIO[i]) begin
+                else if (isMMIO[i] && !stall[i]) begin
                     outUops[i] <= uops[i];
                     outUops[i].isMMIO <= 1;
                     outUops[i].valid <= 1;
@@ -374,7 +374,7 @@ always_ff@(posedge clk) begin
                 end
 
                 // Regular load/store, cache hit
-                else if ((isCacheHit[i] || isCachePassthru[i])) begin
+                else if ((isCacheHit[i] || isCachePassthru[i]) && !stall[i]) begin
                     outUops[i] <= uops[i];
                     outUops[i].isMMIO <= 0;
                     outUops[i].valid <= 1;
@@ -397,9 +397,8 @@ always_ff@(posedge clk) begin
                     if (i == 0) outLdUOp_r <= uopLd;
                     if (i == 1) outStUOp_r <= IN_uopSt;
                 end
-
                 // Evict/Clean/Load cache line
-                else if (!cacheHit[i] && state == IDLE && !temp) begin
+                else if (isCacheMiss[i] && state == IDLE && !temp) begin
                     
                     reg dirty = ctable[cacheIdx[i]][cacheEvictIdx[i]].dirty;
                     for (integer j = 0; j < TOTAL_UOPS; j=j+1)

--- a/src/Config.sv
+++ b/src/Config.sv
@@ -42,7 +42,8 @@
 `define MTIMECMP_ADDR 32'h1100_4000
 //`define ENABLE_UART
 
-// External MMIO starts here
+// External MMIO
+`define ENABLE_EXT_MMIO 0
 `define EXT_MMIO_START_ADDR 32'h1120_0000
 
 // 64 MiB main memory (TODO: make adjustable!) or MMIO

--- a/src/Config.sv
+++ b/src/Config.sv
@@ -23,8 +23,6 @@
 // ROB Size
 `define ROB_SIZE_EXP 6
 
-
-
 // PC at reset
 `define ENTRY_POINT (32'h8000_0000)
 
@@ -36,16 +34,19 @@
 `define IS_MMIO_PMA_W(addr) \
     `IS_MMIO_PMA({(addr), 2'b0})
 
+// Internal MMIO mappings
 `define SPI_ADDR 32'h1000_0000
 `define UART_ADDR 32'h1100_0000
 `define SYSCON_ADDR 32'h1110_0000
 `define MTIME_ADDR 32'h1100_bff8
 `define MTIMECMP_ADDR 32'h1100_4000
 
-// 64 MiB main memory (TODO: make adjustable!)
+// External MMIO starts here
+`define EXT_MMIO_START_ADDR 32'h1120_000
+
+// 64 MiB main memory (TODO: make adjustable!) or MMIO
 `define IS_LEGAL_ADDR(addr) \
     (((addr) >= 32'h80000000 && (addr) < 32'h84000000) || \
     (`IS_MMIO_PMA(addr) && (addr) >= 32'h10000000 && (addr) < 32'h12000000))
-
 
 //`define ENABLE_UART

--- a/src/Config.sv
+++ b/src/Config.sv
@@ -40,13 +40,12 @@
 `define SYSCON_ADDR 32'h1110_0000
 `define MTIME_ADDR 32'h1100_bff8
 `define MTIMECMP_ADDR 32'h1100_4000
+//`define ENABLE_UART
 
 // External MMIO starts here
-`define EXT_MMIO_START_ADDR 32'h1120_000
+`define EXT_MMIO_START_ADDR 32'h1120_0000
 
 // 64 MiB main memory (TODO: make adjustable!) or MMIO
 `define IS_LEGAL_ADDR(addr) \
     (((addr) >= 32'h80000000 && (addr) < 32'h84000000) || \
     (`IS_MMIO_PMA(addr) && (addr) >= 32'h10000000 && (addr) < 32'h12000000))
-
-//`define ENABLE_UART

--- a/src/Core.sv
+++ b/src/Core.sv
@@ -18,7 +18,9 @@ module Core
 
 
 always_comb begin
-    if (CC_MC_if.cmd != MEMC_NONE)
+    if (LSU_MC_if.cmd != MEMC_NONE)
+        OUT_memc = LSU_MC_if;
+    else if (CC_MC_if.cmd != MEMC_NONE)
         OUT_memc = CC_MC_if;
     else
         OUT_memc = PC_MC_if;
@@ -653,6 +655,8 @@ Tag LSU_loadFwdTag;
 wire LSU_ldStall;
 wire LSU_stStall;
 PW_LD_RES_UOp LSU_PW_ldUOp;
+
+CTRL_MemC LSU_MC_if;
 LoadStoreUnit lsu
 (
     .clk(clk),
@@ -664,12 +668,15 @@ LoadStoreUnit lsu
     
     .IN_uopLd(CC_uopLd),
     .IN_uopSt(CC_uopSt),
-
-    .IF_mem(IF_mem),
-    .IF_mmio(IF_mmio),
     
     .IN_SQ_lookupMask(SQ_lookupMask),
     .IN_SQ_lookupData(SQ_lookupData),
+
+    .OUT_memc(LSU_MC_if),
+    .IN_memc(IN_memc),
+    
+    .IF_mem(IF_mem),
+    .IF_mmio(IF_mmio),
     
     .OUT_uopLd(wbUOp[2]),
     .OUT_uopPwLd(LSU_PW_ldUOp),

--- a/src/Core.sv
+++ b/src/Core.sv
@@ -609,6 +609,8 @@ LoadBuffer lb
     .IN_uopLd(AGU_LD_uop),
     .IN_uopSt(AGU_ST_uop),
 
+    .IN_SQ_done(SQ_done),
+
     .OUT_uopLd(LB_uopLd),
     
     .IN_branch(branch),
@@ -621,6 +623,7 @@ wire CSR_we;
 wire[31:0] CSR_dataOut;
 
 wire SQ_empty;
+wire SQ_done;
 ST_UOp SQ_uop;
 wire[3:0] SQ_lookupMask;
 wire[31:0] SQ_lookupData;
@@ -630,9 +633,10 @@ StoreQueue sq
 (
     .clk(clk),
     .rst(rst),
-    .IN_disable(CC_storeStall),
+    .IN_stallSt(CC_storeStall),
     .IN_stallLd(LSU_ldStall),
     .OUT_empty(SQ_empty),
+    .OUT_done(SQ_done),
     
     .IN_uopSt(AGU_ST_uop),
     .IN_uopLd(CC_SQ_uopLd),

--- a/src/ExternalMemorySim.sv
+++ b/src/ExternalMemorySim.sv
@@ -39,14 +39,12 @@ always_ff@(posedge clk) begin
                 addr <= inBus;
                 // Write
                 if (IN_bus[31] == 1) begin
-                    //waitCycles <= 0;
                     state <= 2;
                 end
                 // Read
                 else begin
                     if (IN_bus[29] == 0) begin // MMIO read
                         outBus <= mmioDummy;
-                        mmioDummy <= mmioDummy + 1;
                         OUT_stall <= 0;
                         state <= 0;
                         oen <= 1;
@@ -86,7 +84,7 @@ always_ff@(posedge clk) begin
         3: begin
             if (en) begin
                 outBus <= mem[addr[$clog2(SIZE)-1:0]];
-                addr[29:0] <= addr[29:0] + 1;
+                addr[28:0] <= addr[28:0] + 1;
                 oen <= 1;
             end
             else begin 

--- a/src/ExternalMemorySim.sv
+++ b/src/ExternalMemorySim.sv
@@ -55,6 +55,7 @@ always_ff@(posedge clk) begin
                         // Request one delay cycle such that the read isn't comb
                         OUT_stall <= 1;
                         state <= 3;
+                        oen <= 1;
                     end
                 end
             end
@@ -69,8 +70,14 @@ always_ff@(posedge clk) begin
         // write
         2: begin
             if (en) begin
-                mem[addr[$clog2(SIZE)-1:0]] <= inBus;
-                addr[29:0] <= addr[29:0] + 1;
+                // MMIO
+                if (addr[29] == 0) begin
+                    mmioDummy <= inBus;
+                end
+                else begin
+                    mem[addr[$clog2(SIZE)-1:0]] <= inBus;
+                    addr[28:0] <= addr[28:0] + 1;
+                end
             end
             else state <= 0;
         end

--- a/src/ExternalMemorySim.sv
+++ b/src/ExternalMemorySim.sv
@@ -70,7 +70,8 @@ always_ff@(posedge clk) begin
             if (en) begin
                 // MMIO
                 if (addr[29] == 0) begin
-                    mmioDummy <= inBus;
+                    for (integer i = 0; i < 4; i=i+1)
+                        if (addr[29-4+i]) mmioDummy[8*i+:8] <= inBus[8*i+:8];
                 end
                 else begin
                     mem[addr[$clog2(SIZE)-1:0]] <= inBus;

--- a/src/ICacheTable.sv
+++ b/src/ICacheTable.sv
@@ -62,7 +62,7 @@ enum logic[1:0]
 } state;
 
 always_ff@(posedge clk) begin
-
+    OUT_memc.data <= 'x;
     if (rst) begin
         for (integer i = 0; i < LEN; i=i+1)
             for (integer j = 0; j < ASSOC; j=j+1)

--- a/src/Include.sv
+++ b/src/Include.sv
@@ -11,6 +11,7 @@ typedef enum logic[2:0]
 typedef struct packed
 {
     MemCCmd cmd;
+    logic[31:0] data;
     logic[9:0] sramAddr;
     logic[29:0] extAddr;
     logic[0:0] cacheID;

--- a/src/IssueQueue.sv
+++ b/src/IssueQueue.sv
@@ -73,7 +73,6 @@ typedef struct packed
 } R_ST_UOp;
 
 R_ST_UOp queue[SIZE-1:0];
-reg valid[SIZE-1:0];
 
 reg[$clog2(SIZE):0] insertIndex;
 reg[32:0] reservedWBs;

--- a/src/LoadBuffer.sv
+++ b/src/LoadBuffer.sv
@@ -13,6 +13,8 @@ module LoadBuffer
     input AGU_UOp IN_uopLd,
     input AGU_UOp IN_uopSt,
 
+    input wire IN_SQ_done,
+
     output LD_UOp OUT_uopLd,
     
     input BranchProv IN_branch,
@@ -146,7 +148,7 @@ always_ff@(posedge clk) begin
         end
         else begin
             // Issue Late Ops
-            if (entries[deqIndex].valid && !entries[deqIndex].issued && commitSqN == entries[deqIndex].sqN && !lateLoadUOp.valid) begin
+            if (entries[deqIndex].valid && !entries[deqIndex].issued && commitSqN == entries[deqIndex].sqN && !lateLoadUOp.valid && IN_SQ_done) begin
                 // can we just pretend that the op was committed here to speed things up? commit should be guaranteed.
                 lateLoadUOp <= entries[deqIndex];
                 entries[deqIndex].issued <= 1;

--- a/src/LoadStoreUnit.sv
+++ b/src/LoadStoreUnit.sv
@@ -4,18 +4,21 @@ module LoadStoreUnit
     input wire rst,
     
     input BranchProv IN_branch,
-    output reg OUT_ldStall,
+    output wire OUT_ldStall,
     output reg OUT_stStall,
     
     input LD_UOp IN_uopLd,
     input ST_UOp IN_uopSt,
-    
-    IF_Mem.HOST IF_mem,
-    IF_MMIO.HOST IF_mmio,
-    
+
     // Forwarded data from store queue
     input wire[3:0] IN_SQ_lookupMask,
     input wire[31:0] IN_SQ_lookupData,
+    
+    IF_Mem.HOST IF_mem,
+    IF_MMIO.HOST IF_mmio,
+
+    output CTRL_MemC OUT_memc,
+    input STAT_MemC IN_memc,
     
     output RES_UOp OUT_uopLd,
     output PW_LD_RES_UOp OUT_uopPwLd,
@@ -23,7 +26,6 @@ module LoadStoreUnit
     output wire OUT_loadFwdValid,
     output Tag OUT_loadFwdTag
 );
-
 
 typedef struct packed
 {
@@ -50,6 +52,32 @@ endfunction
 Stage uopLd_0;
 Stage uopLd_1;
 
+assign OUT_ldStall = BLSU_ldStall;
+
+wire isCacheBypassLdUOp = IN_uopLd.isMMIO && IN_uopLd.addr >= `EXT_MMIO_START_ADDR;
+wire BLSU_ldStall;
+LD_UOp BLSU_uopLd;
+wire[31:0] BLSU_ldResult;
+Stage BLSU_stageUOpLd;
+assign BLSU_stageUOpLd = {BLSU_ldResult, 4'b1111, BLSU_uopLd};
+BypassLSU bypassLSU
+(
+    .clk(clk),
+    .rst(rst),
+    
+    .IN_branch(IN_branch),
+    .IN_uopLdEn(isCacheBypassLdUOp),
+    .OUT_ldStall(BLSU_ldStall),
+    .IN_uopLd(IN_uopLd),
+
+    .IN_stall(uopLd_1.valid),
+    .OUT_uopLd(BLSU_uopLd),
+    .OUT_ldData(BLSU_ldResult),
+
+    .OUT_memc(OUT_memc),
+    .IN_memc(IN_memc)
+);
+
 wire forwardUOpLd_0 = (uopLd_0.valid && !uopLd_0.external);
 assign OUT_loadFwdValid = forwardUOpLd_0 || (!IN_uopLd.external && IN_uopLd.valid && IN_SQ_lookupMask == 4'b1111 && !uopLd_0.valid);
 assign OUT_loadFwdTag = forwardUOpLd_0 ? uopLd_0.tagDst : IN_uopLd.tagDst;
@@ -60,11 +88,10 @@ always_comb begin
 end
 
 wire doRead = IN_uopLd.valid && (IN_uopLd.external || !IN_branch.taken || $signed(IN_uopLd.sqN - IN_branch.sqN) <= 0) &&
-    (IN_SQ_lookupMask != 4'b1111 || IN_uopLd.external);
+    (IN_SQ_lookupMask != 4'b1111 || IN_uopLd.external) && !isCacheBypassLdUOp;
 
 always_comb begin
     
-    OUT_ldStall = 0;
     OUT_stStall = 0;
     
     IF_mmio.raddr = IN_uopLd.addr;
@@ -112,37 +139,40 @@ always_comb begin
 end
 
 always_comb begin
+    
+    Stage ld = uopLd_1.valid ? uopLd_1 : BLSU_stageUOpLd;
     reg[31:0] result = 32'bx;
     reg[31:0] data;
-    data[31:24] = uopLd_1.wmask[3] ? uopLd_1.data[31:24] : 
-        (uopLd_1.isMMIO ?  IF_mmio.rdata[31:24] : IF_mem.rdata[31:24]);
-    data[23:16] = uopLd_1.wmask[2] ? uopLd_1.data[23:16] : 
-        (uopLd_1.isMMIO ? IF_mmio.rdata[23:16] : IF_mem.rdata[23:16]);
-    data[15:8] = uopLd_1.wmask[1] ? uopLd_1.data[15:8] : 
-        (uopLd_1.isMMIO ? IF_mmio.rdata[15:8] : IF_mem.rdata[15:8]);
-    data[7:0] = uopLd_1.wmask[0] ? uopLd_1.data[7:0] : 
-        (uopLd_1.isMMIO ? IF_mmio.rdata[7:0] : IF_mem.rdata[7:0]);
+
+    data[31:24] = ld.wmask[3] ? ld.data[31:24] : 
+        (ld.isMMIO ?  IF_mmio.rdata[31:24] : IF_mem.rdata[31:24]);
+    data[23:16] = ld.wmask[2] ? ld.data[23:16] : 
+        (ld.isMMIO ? IF_mmio.rdata[23:16] : IF_mem.rdata[23:16]);
+    data[15:8] = ld.wmask[1] ? ld.data[15:8] : 
+        (ld.isMMIO ? IF_mmio.rdata[15:8] : IF_mem.rdata[15:8]);
+    data[7:0] = ld.wmask[0] ? ld.data[7:0] : 
+        (ld.isMMIO ? IF_mmio.rdata[7:0] : IF_mem.rdata[7:0]);
     
-    case (uopLd_1.size)
+    case (ld.size)
         
         0: begin
-            case (uopLd_1.addr[1:0])
+            case (ld.addr[1:0])
                 0: result[7:0] = data[7:0];
                 1: result[7:0] = data[15:8];
                 2: result[7:0] = data[23:16];
                 3: result[7:0] = data[31:24];
             endcase
             
-            result[31:8] = {24{uopLd_1.signExtend ? result[7] : 1'b0}};
+            result[31:8] = {24{ld.signExtend ? result[7] : 1'b0}};
         end
         
         1: begin
-            case (uopLd_1.addr[1:0])
+            case (ld.addr[1:0])
                 default: result[15:0] = data[15:0];
                 2: result[15:0] = data[31:16];
             endcase
             
-            result[31:16] = {16{uopLd_1.signExtend ? result[15] : 1'b0}};
+            result[31:16] = {16{ld.signExtend ? result[15] : 1'b0}};
         end
         
         default: result = data;
@@ -151,20 +181,20 @@ always_comb begin
     OUT_uopLd = 'x;
     OUT_uopPwLd = 'x;
     
-    OUT_uopLd.valid = uopLd_1.valid && !uopLd_1.external;
-    OUT_uopPwLd.valid = uopLd_1.valid && uopLd_1.external;
+    OUT_uopLd.valid = ld.valid && !ld.external;
+    OUT_uopPwLd.valid = ld.valid && ld.external;
     
     if (OUT_uopLd.valid) begin
         OUT_uopLd.result = result;
-        OUT_uopLd.tagDst = uopLd_1.tagDst;
-        OUT_uopLd.sqN = uopLd_1.sqN;
-        case (uopLd_1.exception)
+        OUT_uopLd.tagDst = ld.tagDst;
+        OUT_uopLd.sqN = ld.sqN;
+        case (ld.exception)
             AGU_NO_EXCEPTION: OUT_uopLd.flags = FLAGS_NONE;
             AGU_ADDR_MISALIGN: OUT_uopLd.flags = FLAGS_LD_MA;
             AGU_ACCESS_FAULT: OUT_uopLd.flags = FLAGS_LD_AF;
             AGU_PAGE_FAULT: OUT_uopLd.flags = FLAGS_LD_PF;
         endcase
-        OUT_uopLd.doNotCommit = uopLd_1.doNotCommit;
+        OUT_uopLd.doNotCommit = ld.doNotCommit;
     end
     
     if (OUT_uopPwLd.valid) begin
@@ -195,9 +225,11 @@ always_ff@(posedge clk) begin
                 uopLd_1.data <= IN_SQ_lookupData;
             end
             else begin
-                uopLd_0 <= ToStage(IN_uopLd);
-                uopLd_0.wmask <= IN_uopLd.external ? 4'b0000 : IN_SQ_lookupMask;
-                uopLd_0.data <= IN_SQ_lookupData;
+                if (!isCacheBypassLdUOp) begin
+                    uopLd_0 <= ToStage(IN_uopLd);
+                    uopLd_0.wmask <= IN_uopLd.external ? 4'b0000 : IN_SQ_lookupMask;
+                    uopLd_0.data <= IN_SQ_lookupData;
+                end
             end
         end
     end

--- a/src/LoadStoreUnit.sv
+++ b/src/LoadStoreUnit.sv
@@ -58,8 +58,8 @@ Stage uopLd_1;
 
 assign OUT_ldStall = BLSU_ldStall;
 
-wire isCacheBypassLdUOp = IN_uopLd.valid && IN_uopLd.isMMIO && IN_uopLd.addr >= `EXT_MMIO_START_ADDR;
-wire isCacheBypassStUOp = IN_uopSt.valid && IN_uopSt.isMMIO && IN_uopSt.addr >= `EXT_MMIO_START_ADDR;
+wire isCacheBypassLdUOp = `ENABLE_EXT_MMIO && IN_uopLd.valid && IN_uopLd.isMMIO && IN_uopLd.addr >= `EXT_MMIO_START_ADDR;
+wire isCacheBypassStUOp = `ENABLE_EXT_MMIO && IN_uopSt.valid && IN_uopSt.isMMIO && IN_uopSt.addr >= `EXT_MMIO_START_ADDR;
 
 wire BLSU_ldStall;
 LD_UOp BLSU_uopLd;

--- a/src/MemoryInterface.sv
+++ b/src/MemoryInterface.sv
@@ -88,7 +88,7 @@ always_ff@(posedge clk) begin
                 waitCycles <= waitCycles - 1;
                 if (waitCycles == 1) begin
                     OUT_EXT_oen <= isWrite;
-                    if (lenCnt <= 2) OUT_EXT_en <= 0;
+                    if (lenCnt <= 2 && !isWrite) OUT_EXT_en <= 0;
                 end
             end
             else begin
@@ -110,7 +110,10 @@ always_ff@(posedge clk) begin
                         if (lenCnt <= 2) 
                             OUT_EXT_en <= 0;
 
-                        if (lenCnt == 1) active <= 0;
+                        if (lenCnt == 1) begin
+                            active <= 0;
+                            OUT_EXT_oen <= 1;
+                        end
                         else lenCnt <= lenCnt - 1;
                     end 
                 end

--- a/src/StoreQueue.sv
+++ b/src/StoreQueue.sv
@@ -16,9 +16,10 @@ module StoreQueue
 (
     input wire clk,
     input wire rst,
-    input wire IN_disable,
+    input wire IN_stallSt,
     input wire IN_stallLd,
     output reg OUT_empty,
+    output reg OUT_done,
     
     input AGU_UOp IN_uopSt,
     input LD_UOp IN_uopLd,
@@ -105,7 +106,6 @@ reg flushing;
 assign OUT_flush = flushing;
 reg doingEnqueue;
 always_ff@(posedge clk) begin
-    
     didCSRwrite <= 0;
     doingEnqueue = 0;
     if (!IN_stallLd) begin
@@ -126,18 +126,22 @@ always_ff@(posedge clk) begin
         OUT_empty <= 1;
         OUT_uopSt.valid <= 0;
         flushing <= 0;
+        OUT_done <= 1;
     end
     
     else begin
         
+        OUT_done <= (empty || (!entries[0].ready && !($signed(IN_curSqN - entries[0].sqN) > 0))) && !IN_stallSt;
+
         // Set entries of committed instructions to ready
         for (integer i = 0; i < NUM_ENTRIES; i=i+1) begin
-            if ($signed(IN_curSqN - entries[i].sqN) > 0)
+            if ($signed(IN_curSqN - entries[i].sqN) > 0) begin
                 entries[i].ready <= 1;
+            end
         end
         
         // Dequeue
-        if (!IN_disable && entries[0].valid && !IN_branch.taken && entries[0].ready &&
+        if (!IN_stallSt && entries[0].valid && !IN_branch.taken && entries[0].ready &&
             // Don't issue Memory Mapped IO ops while IO is not ready
             (!(didCSRwrite) || `IS_MMIO_PMA_W(entries[0].addr))) begin
                 
@@ -158,11 +162,13 @@ always_ff@(posedge clk) begin
                 if ($signed(IN_curSqN - entries[i].sqN) > 0)
                     entries[i-1].ready <= 1;
             end
-                
+            
+            OUT_done <= 0;
+
             evicted[1] <= entries[0];
             evicted[0] <= evicted[1];
         end
-        else if (!IN_disable) OUT_uopSt.valid <= 0;
+        else if (!IN_stallSt) OUT_uopSt.valid <= 0;
         
         // Invalidate
         if (IN_branch.taken) begin

--- a/src/StoreQueue.sv
+++ b/src/StoreQueue.sv
@@ -102,6 +102,8 @@ always_comb begin
     end
 end
 
+assign OUT_done = (!entries[0].valid || (!entries[0].ready && !($signed(IN_curSqN - entries[0].sqN) > 0))) && !IN_stallSt;
+
 reg flushing;
 assign OUT_flush = flushing;
 reg doingEnqueue;
@@ -126,12 +128,9 @@ always_ff@(posedge clk) begin
         OUT_empty <= 1;
         OUT_uopSt.valid <= 0;
         flushing <= 0;
-        OUT_done <= 1;
     end
     
     else begin
-        
-        OUT_done <= (empty || (!entries[0].ready && !($signed(IN_curSqN - entries[0].sqN) > 0))) && !IN_stallSt;
 
         // Set entries of committed instructions to ready
         for (integer i = 0; i < NUM_ENTRIES; i=i+1) begin
@@ -162,8 +161,6 @@ always_ff@(posedge clk) begin
                 if ($signed(IN_curSqN - entries[i].sqN) > 0)
                     entries[i-1].ready <= 1;
             end
-            
-            OUT_done <= 0;
 
             evicted[1] <= entries[0];
             evicted[0] <= evicted[1];

--- a/test_programs/external_mmio.s
+++ b/test_programs/external_mmio.s
@@ -6,6 +6,7 @@ main:
     li s1, 100
     .loop:
         lw a0, 0(s0)
+        sw x0, 0(s0)
         call printhex
         addi s1, s1, -1
         bnez s1, .loop

--- a/test_programs/external_mmio.s
+++ b/test_programs/external_mmio.s
@@ -1,0 +1,14 @@
+.text
+.globl main
+main:
+    mv s2, ra
+    li s0, 0x11200000
+    li s1, 100
+    .loop:
+        lw a0, 0(s0)
+        call printhex
+        addi s1, s1, -1
+        bnez s1, .loop
+    
+    mv ra, s2
+    ret

--- a/test_programs/external_mmio.s
+++ b/test_programs/external_mmio.s
@@ -3,13 +3,14 @@
 main:
     mv s2, ra
     li s0, 0x11200000
+    sw zero, 0(s0)
     li s1, 100
     .loop:
-        lw a0, 0(s0)
-        sw x0, 0(s0)
-        call printhex
         addi s1, s1, -1
-        bnez s1, .loop
+        sb s1, 1(s0)
+        lw a0, 0(s0)
+        call printhex
+        bgez s1, .loop
     
     mv ra, s2
     ret


### PR DESCRIPTION
Implement non-cached access to external bus in a defined memory region. This allows implementing MMIO devices out-of-core -- as opposed to current MMIO devices such as UART and ACLINT, which are implemented in-core.