### PR TITLE
Remove unused port IN_pc

### DIFF
--- a/src/BranchPredictor.sv
+++ b/src/BranchPredictor.sv
@@ -186,7 +186,6 @@ ReturnStack retStack
     .OUT_stall(RET_stall),
 
     .IN_valid(IN_pcValid),
-    .IN_pc(OUT_pc),
     .IN_fetchID(IN_fetchID),
     .IN_comFetchID(IN_comFetchID),
 

--- a/src/ReturnStack.sv
+++ b/src/ReturnStack.sv
@@ -10,7 +10,6 @@ module ReturnStack
 
     // IFetch time push/pop
     input wire IN_valid,
-    input wire[30:0] IN_pc,
     input FetchID_t IN_fetchID,
     input FetchID_t IN_comFetchID,
 


### PR DESCRIPTION
	modified:   src/BranchPredictor.sv
	modified:   src/ReturnStack.sv
        the 32-bit IN_pc port is not used in the ReturnStack module.